### PR TITLE
Navigate past Wiley's iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This works with journals such as:
 
  - PNAS
  - Molecular Biology and Evolution
- - ASPB Journals
+ - Wiley
 
 and many others! You can install the Google Chrome Extension directly from [the
 Google Chrome Web

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "description": "Changes links to PDFs of journal articles to the PDF version (not HTML+PDF version with frames)",
 
   "manifest_version": 2,
-  "version": "1.2",
+  "version": "1.3",
   "permissions": [
     "http://*/*"
     ],
@@ -12,6 +12,11 @@
   {
     "matches": ["http://*/*"],
     "js": ["jquery-2.1.1.min.js", "gmtfpdf.js"],
+    "run_at": "document_end"
+  },
+  {
+    "matches": ["http://onlinelibrary.wiley.com/doi/*/pdf"],
+    "js": ["wiley.js"],
     "run_at": "document_end"
   }
   ]

--- a/wiley.js
+++ b/wiley.js
@@ -1,0 +1,13 @@
+// Wrap in a function to allow try/catch-and-return safeguard, calling it immediately
+
+(function GoToWileyPDF() {
+  try {
+    pdf_iframe = document.querySelector('iframe#pdfDocument');
+    pdf_link = pdf_iframe.getAttribute('src');
+    // Navigate directly to the PDF
+    window.location.href = pdf_link;
+  } catch(e) {
+    console.log("Error while attempting to determine PDF URL:\n", e)
+    return
+  }
+})();


### PR DESCRIPTION
A simpler solution than using chrome.tabs API (#4) but it works - Wiley PDFs no longer within iframes

I made a fancier version which got the PDF short URL and `document.title`, stored them as JSON in `localStorage` with the direct PDF URL as the key before navigating to the direct link. Running `window.history.replaceState(null, original title, original window.location.pathname)` made the URL match the original, but turns out calling the `history` API breaks `Ctrl` + `S` save as (the browser thinks the page is HTML)

Would be nice if future browsers fixed that - could have a neater address bar.

This should be ready to put on the webstore anyway, I've incremented the manifest version for you :-)
